### PR TITLE
Add cheaper LLM, and refactor consolidate_units function

### DIFF
--- a/ai_agent/config.py
+++ b/ai_agent/config.py
@@ -4,8 +4,14 @@ import settings
 
 SYSTEM_PROMPT_PREFIX = "You are a helpful assistant specializing in recipe analysis."
 rate_limiter = InMemoryRateLimiter(
-    requests_per_second=0.1,  # <-- Super slow! We can only make a request once every 10 seconds!!
+    requests_per_second=2,  # <-- Super slow! We can only make a request once every 0.5 seconds!!
     check_every_n_seconds=0.1,  # Wake up every 100 ms to check whether allowed to make a request,
     max_bucket_size=10,  # Controls the maximum burst size.
 )
-llm = ChatOpenAI(temperature=0.2, openai_api_key=settings.env_settings.openai_api_key, model_name="gpt-4o", rate_limiter=rate_limiter)
+llm = ChatOpenAI(temperature=0.2, openai_api_key=settings.env_settings.openai_api_key, model_name="gpt-4o")
+cheaper_llm = ChatOpenAI(
+    temperature=0.2,
+    openai_api_key=settings.env_settings.openai_api_key,
+    model_name="gpt-4o-mini",
+    rate_limiter=rate_limiter,
+)

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ from ai_agent.agent import run_agent
 
 if __name__ == "__main__":
     example_inputs = [
-        "https://www.kwestiasmaku.com/przepis/kurczak-w-sosie-curry",
+        "https://www.kwestiasmaku.com/przepis/kurczak-w-sosie-curry/",
         """
         **Simple Pancake Recipe**
 
@@ -48,4 +48,4 @@ if __name__ == "__main__":
         "https://headbangerskitchen.com/indian-curry-chicken-curry/",
     ]
 
-    asyncio.run(run_agent(example_inputs[3]))
+    asyncio.run(run_agent(example_inputs[3:4]))


### PR DESCRIPTION
This PR improves the recipe analysis performance by increasing the rate limiter speed, introducing a cheaper LLM option, and refactoring the consolidate_units function.

- Updated main.py to adjust the recipe URL format and modify the run_agent input.
- Revised ai_agent/tools.py to remove debug prints and update the chain to use the cheaper_llm.
- Modified ai_agent/config.py to increase the rate limiter speed and instantiate a new cheaper_llm with rate limiting.
